### PR TITLE
Disalbe paste mode again after pasting perltidy output

### DIFF
--- a/ftplugin/perl/perltidy.vim
+++ b/ftplugin/perl/perltidy.vim
@@ -34,6 +34,7 @@ function!s:PerlTidy()
     call setpos(".", prevcur)
     call setpos("'x", prevx)
     call setpos("'y", prevy)
+    set nopaste
 endfunction
 
 command! -nargs=* -range -bang PerlTidy <line1>,<line2>call s:PerlTidy()


### PR DESCRIPTION
Since paste mode is enabled when saving a file, it should also be disabled again. Otherwise one is left with e.g. broken code indentation settings.